### PR TITLE
Use pathname for scroll restoration key

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,6 +17,7 @@ export const getRouter = () => {
 
     defaultPreload: 'intent',
     scrollRestoration: true,
+    getScrollRestorationKey: (location) => location.pathname,
   })
 
   setupRouterSsrQueryIntegration({ router, queryClient: rqContext.queryClient })


### PR DESCRIPTION
Add getScrollRestorationKey to the router config to use location.pathname as the restoration key. This ensures scroll positions are tracked per-path (ignoring query params) and yields more consistent scroll restoration across navigations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll position restoration when navigating between pages. Each page now independently maintains and restores its scroll position for a better browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->