### PR TITLE
Use async mutation and revoke other sessions

### DIFF
--- a/src/components/dashboard/password-drawer.tsx
+++ b/src/components/dashboard/password-drawer.tsx
@@ -36,7 +36,7 @@ const passwordChangeSchema = z
   })
 
 const PasswordDrawer = () => {
-  const { mutate, isPending } = useMutation({
+  const { mutateAsync, isPending } = useMutation({
     mutationFn: async (data: {
       currentPassword: string
       newPassword: string
@@ -45,7 +45,7 @@ const PasswordDrawer = () => {
       const result = await authClient.changePassword({
         newPassword: data.newPassword,
         currentPassword: data.currentPassword,
-        revokeOtherSessions: false,
+        revokeOtherSessions: true,
       })
 
       if (result.error) {
@@ -75,7 +75,10 @@ const PasswordDrawer = () => {
       onSubmit: passwordChangeSchema,
     },
     onSubmit: async ({ value }) => {
-      mutate(value)
+      toast.promise(mutateAsync(value), {
+        success: 'Password changed successfully',
+        error: 'Failed to change password. Please try again.',
+      })
     },
   })
 


### PR DESCRIPTION
Switch from mutate to mutateAsync from useMutation and wrap the password-change call in toast.promise to surface success/error feedback to the user. Also set revokeOtherSessions to true so password changes invalidate other sessions. This makes the onSubmit flow await the mutation and provide clearer UI messaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user feedback notifications (success/failure) when changing password.

* **Bug Fixes**
  * Updated password change security behavior to revoke other active sessions upon password update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->